### PR TITLE
Fix bug: "options.fromBuild || true", always true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (source) {
   if (this.cacheable) this.cacheable();
   var callback  = this.async();
   var options   = this.options.toolbox || {};
-  var fromBuild = options.fromBuild || true;
+  var fromBuild = options.fromBuild !== false;
   var themeName = options.theme || DEFAULT_NAME;
   var themePath = path.resolve(themeName);
 


### PR DESCRIPTION
`var fromBuild = options.fromBuild || true;`

`fromBuild` will always be true.
